### PR TITLE
Adding support for Laravel 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }],
     "require": {
         "php": "^5.6 || ^7.0",
-        "illuminate/support": "5.1.* || 5.2.* || 5.3.*",
+        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.*",
         "erusev/parsedown": "^1.6"
     },
     "require-dev": {


### PR DESCRIPTION
Can we get Laravel 5.4 support while not requiring PHP 7.1?